### PR TITLE
fix stale cache totals after match upload

### DIFF
--- a/backend/fantasyVCT/interactions.py
+++ b/backend/fantasyVCT/interactions.py
@@ -599,16 +599,10 @@ class StatsCog(commands.Cog, name="Stats"):
 
 		def get_fantasy_points(cache, player):
 			"""Retrieve the fantasy points value of the given db.Player"""
-			total = cache.retrieve_total(player.id)
-			if not total:
-				for row in player.results:
-					fantasy_points = self.bot.cache.retrieve(player.id, row.game_id)
-					if not fantasy_points:
-						# game is not in cache, so perform calculation
-						fantasy_points = PointCalculator.score(row)
-						cache.store(player.id, row.game_id, fantasy_points)
-				total = cache.retrieve_total(player.id)
-			return total
+			for row in player.results:
+				if not cache.retrieve(player.id, row.game_id):
+					cache.store(player.id, row.game_id, PointCalculator.score(row))
+			return cache.retrieve_total(player.id)
 
 		buf = "```Player Rankings\n"
 		line = add_spaces("", 4) + "Player"

--- a/backend/fantasyVCT/scoring.py
+++ b/backend/fantasyVCT/scoring.py
@@ -45,6 +45,7 @@ class Cache:
 		if not player_id in self._store:
 			self._store[player_id] = {-1 : None}
 		self._store[player_id][key] = value
+		self._store[player_id][-1] = None
 
 	def retrieve(self, player_id: int, key: int = None):
 		"""Retrieve a specific value or all values associated with a player id.

--- a/backend/test/test_interactions.py
+++ b/backend/test/test_interactions.py
@@ -210,6 +210,55 @@ async def test_standings_shows_team(mock_bot, ctx, engine):
 	assert "MyTeam" in sent
 
 
+# ── StatsCog.rankplayers() ────────────────────────────────────────────────────
+
+async def test_rankplayers_picks_up_new_games_after_stale_total(mock_bot, ctx, engine):
+	# Regression: get_fantasy_points used `if not total` guard, so new games
+	# added after a stale total was cached were never fetched from the DB.
+	from fantasyVCT.scoring import Cache
+	from fantasyVCT.database import Result
+
+	def _result(pid, eid, game_id, kills):
+		return Result(player_id=pid, game_id=game_id, match_id="m1",
+			map="Haven", event_id=eid, agent="Jett",
+			player_acs=0, player_kills=kills, player_deaths=0, player_assists=0,
+			player_2k=0, player_3k=0, player_4k=0, player_5k=0,
+			player_clutch_v2=0, player_clutch_v3=0, player_clutch_v4=0, player_clutch_v5=0)
+
+	with SASession(engine) as s:
+		event = db.Event(name="TestEvent")
+		team = db.Team(name="ProTeam", abbrev="PRO", region="na")
+		s.add_all([event, team])
+		s.flush()
+		player = db.Player(name="TestPlayer", team_id=team.id)
+		s.add(player)
+		s.flush()
+		s.add(_result(player.id, event.id, game_id=1, kills=10))
+		s.add(_result(player.id, event.id, game_id=2, kills=5))
+		s.commit()
+		pid, eid = player.id, event.id
+
+	# Simulate stale cache state: old games cached, total rebuilt to stale value
+	cache = Cache()
+	cache.store(pid, 1, 20.0)
+	cache.store(pid, 2, 10.0)
+	cache.retrieve_total(pid)   # caches 30.0
+	cache.invalidate()
+	cache.retrieve_total(pid)   # rebuilds stale 30.0 from old entries
+
+	# New game added to DB (simulating an upload)
+	with SASession(engine) as s:
+		s.add(_result(pid, eid, game_id=3, kills=20))
+		s.commit()
+
+	mock_bot.cache = cache
+	cog = StatsCog(mock_bot)
+	await cog.rankplayers.callback(cog, ctx)
+	sent = "".join(call[0][0] for call in ctx.send.call_args_list)
+	# game 3: 20 kills * 2 = 40.0; total should be 20+10+40 = 70.0, not stale 30.0
+	assert "70.0" in sent
+
+
 # ── _optimal_score ────────────────────────────────────────────────────────────
 
 def _make_fp(player_id, team_id):

--- a/backend/test/test_scoring.py
+++ b/backend/test/test_scoring.py
@@ -126,3 +126,30 @@ class TestCache:
         cache.store(2, 101, 99.0)
         assert cache.retrieve_total(1) == 10.0
         assert cache.retrieve_total(2) == 99.0
+
+    def test_store_invalidates_cached_total(self):
+        # Bug fix: store() must reset the cached total so retrieve_total
+        # recalculates after new games are added.
+        cache = Cache()
+        cache.store(1, 101, 10.0)
+        cache.store(1, 102, 8.0)
+        assert cache.retrieve_total(1) == 18.0  # total cached as 18.0
+        # new game arrives
+        cache.store(1, 103, 42.0)
+        # total must reflect all three games, not the stale 18.0
+        assert cache.retrieve_total(1) == 60.0
+
+    def test_stale_total_not_returned_after_new_game(self):
+        # Simulates the upload → retrieve_total → store new game → retrieve_total
+        # sequence that triggered the !info and !standings stale total bug.
+        cache = Cache()
+        cache.store(1, 101, 11.2)
+        cache.store(1, 102, 8.1)
+        cache.retrieve_total(1)   # caches 19.3 at key -1
+        cache.invalidate()        # clears -1 back to None
+        cache.retrieve_total(1)   # rebuilds from old entries → 19.3 stored at -1
+        # new games added (as !info / !standings loop would do)
+        cache.store(1, 103, 42.4)
+        cache.store(1, 104, 23.9)
+        # must return full total, not the stale 19.3
+        assert cache.retrieve_total(1) == 85.6


### PR DESCRIPTION
Bug 1 (scoring.py): cache.store() never reset the cached total key (-1), so retrieve_total() returned stale totals even after new games were added. Fix: reset -1 to None on every store() call. Affects !roster, !freeagents, !standings, !info, and !rankplayers.

Bug 2 (interactions.py): get_fantasy_points() in !rankplayers used `if not total:` as a guard, skipping the DB fetch entirely when any cached total existed. Fix: use the same per-game pattern as every other command — always iterate player.results, only skip cached individual games.